### PR TITLE
Datatypes now cross platform compatible

### DIFF
--- a/ncls/src/cncls.pxd
+++ b/ncls/src/cncls.pxd
@@ -1,18 +1,18 @@
-
+from libc.stdint cimport int32_t
 # cdef extern from "string.h":
-#   ctypedef int size_t
+#   ctypedef int32_t size_t
 #   void *memcpy(void *dst,void *src,size_t len)
 #   void *memmove(void *dst,void *src,size_t len)
-#   void *memset(void *b,int c,size_t len)
+#   void *memset(void *b,int32_t c,size_t len)
 
 cdef extern from "stdlib.h":
   void free(void *)
   void *malloc(size_t)
   void *calloc(size_t,size_t)
   void *realloc(void *,size_t)
-  int c_abs "abs" (int)
+  int32_t c_abs "abs" (int32_t)
   void qsort(void *base, size_t nmemb, size_t size,
-             int (*compar)(void *,void *))
+             int32_t (*compar)(void *,void *))
 
 cdef extern from "stdio.h":
   ctypedef struct FILE:
@@ -22,16 +22,16 @@ cdef extern from "stdio.h":
   FILE *open_memstream(void *, size_t *)
   FILE *fmemopen (void *, size_t, const char *)
 
-  int fclose(FILE *)
-  int fflush(FILE *)
-  int sscanf(char *str,char *fmt,...)
-  int sprintf(char *str,char *fmt,...)
-  int fprintf(FILE *ifile,char *fmt,...)
-  char *fgets(char *str,int size,FILE *ifile)
+  int32_t fclose(FILE *)
+  int32_t fflush(FILE *)
+  int32_t sscanf(char *str,char *fmt,...)
+  int32_t sprintf(char *str,char *fmt,...)
+  int32_t fprintf(FILE *ifile,char *fmt,...)
+  char *fgets(char *str,int32_t size,FILE *ifile)
 
 # cdef extern from "string.h":
-#   int strcmp(char *s1, char *s2)
-#   int strncmp(char *s1,char *s2,size_t len)
+#   int32_t strcmp(char *s1, char *s2)
+#   int32_t strncmp(char *s1,char *s2,size_t len)
 #   char *strcpy(char *dest,char *src)
 #   char *strdup(char *)
 #   char *strcat(char *,char *)
@@ -39,62 +39,62 @@ cdef extern from "stdio.h":
 
 cdef extern from "ncls/src/intervaldb.h":
     ctypedef struct IntervalMap:
-        int start
-        int end
-        int target_id
-        int sublist
+        int32_t start
+        int32_t end
+        int32_t target_id
+        int32_t sublist
 
     ctypedef struct IntervalIterator:
         pass
 
     ctypedef struct SublistHeader:
-        int start
-        int len
+        int32_t start
+        int32_t len
 
-    int find_overlap_start(int start, int end, IntervalMap im[], int n)
-    int imstart_qsort_cmp(void *void_a,void *void_b)
-    # int target_qsort_cmp(void *void_a,void *void_b)
-    IntervalMap *read_intervals(int n,FILE *ifile)
-    SublistHeader *build_nested_list(IntervalMap im[],int n,int *p_n,int *p_nlists)
-    SublistHeader *build_nested_list_inplace(IntervalMap im[],int n,int *p_n,int *p_nlists)
-    IntervalMap *interval_map_alloc(int n)
+    int32_t find_overlap_start(int32_t start, int32_t end, IntervalMap im[], int32_t n)
+    int32_t imstart_qsort_cmp(void *void_a,void *void_b)
+    # int32_t target_qsort_cmp(void *void_a,void *void_b)
+    IntervalMap *read_intervals(int32_t n,FILE *ifile)
+    SublistHeader *build_nested_list(IntervalMap im[],int32_t n,int32_t *p_n,int32_t *p_nlists)
+    SublistHeader *build_nested_list_inplace(IntervalMap im[],int32_t n,int32_t *p_n,int32_t *p_nlists)
+    IntervalMap *interval_map_alloc(int32_t n)
     IntervalIterator *interval_iterator_alloc()
-    int free_interval_iterator(IntervalIterator *it)
+    int32_t free_interval_iterator(IntervalIterator *it)
     IntervalIterator *reset_interval_iterator(IntervalIterator *it)
-    int *alloc_array(int n)
-    int find_intervals_stack(int start_stack[], int end_stack[], int sp, int start,
-                             int end, IntervalMap im[], int n,
+    int32_t *alloc_array(int32_t n)
+    int32_t find_intervals_stack(int32_t start_stack[], int32_t end_stack[], int32_t sp, int32_t start,
+                             int32_t end, IntervalMap im[], int32_t n,
                              SublistHeader subheader[], IntervalMap buf[],
-                             int *nfound)
+                             int32_t *nfound)
 
-    int find_intervals(IntervalIterator *it0,
-                       int start,
-                       int end,
+    int32_t find_intervals(IntervalIterator *it0,
+                       int32_t start,
+                       int32_t end,
                        IntervalMap im[],
-                       int n,
+                       int32_t n,
                        SublistHeader subheader[],
-                       int nlists,
+                       int32_t nlists,
                        IntervalMap buf[],
-                       int nbuf,
-                       int *p_nreturn,
+                       int32_t nbuf,
+                       int32_t *p_nreturn,
                        IntervalIterator **it_return)
-    void find_k_next(int start, int end,
-                    IntervalMap im[], int n,
-                    SublistHeader subheader[], int nlists,
-                    IntervalMap buf[], int ktofind,
-                    int *p_nreturn)
+    void find_k_next(int32_t start, int32_t end,
+                    IntervalMap im[], int32_t n,
+                    SublistHeader subheader[], int32_t nlists,
+                    IntervalMap buf[], int32_t ktofind,
+                    int32_t *p_nreturn)
 
-    # char *write_binary_files(IntervalMap im[],int n,int ntop,int div,SublistHeader *subheader,int nlists,char filestem[])
-    # IntervalDBFile *read_binary_files(char filestem[],char err_msg[],int subheader_nblock) except NULL
-    # int free_interval_dbfile(IntervalDBFile *db_file)
-    # int find_file_intervals(IntervalIterator *it0,int start,int end,IntervalIndex ii[],int nii,SublistHeader subheader[],int nlists,SubheaderFile *subheader_file,int ntop,int div,FILE *ifile,IntervalMap buf[],int nbuf,int *p_nreturn,IntervalIterator **it_return) except -1
-    # int write_padded_binary(IntervalMap im[],int n,int div,FILE *ifile)
+    # char *write_binary_files(IntervalMap im[],int32_t n,int32_t ntop,int32_t div,SublistHeader *subheader,int32_t nlists,char filestem[])
+    # IntervalDBFile *read_binary_files(char filestem[],char err_msg[],int32_t subheader_nblock) except NULL
+    # int32_t free_interval_dbfile(IntervalDBFile *db_file)
+    # int32_t find_file_intervals(IntervalIterator *it0,int32_t start,int32_t end,IntervalIndex ii[],int32_t nii,SublistHeader subheader[],int32_t nlists,SubheaderFile *subheader_file,int32_t ntop,int32_t div,FILE *ifile,IntervalMap buf[],int32_t nbuf,int32_t *p_nreturn,IntervalIterator **it_return) except -1
+    # int32_t write_padded_binary(IntervalMap im[],int32_t n,int32_t div,FILE *ifile)
 
-    int read_imdiv(FILE *ifile,IntervalMap imdiv[],int div,int i_div,int ntop)
+    int32_t read_imdiv(FILE *ifile,IntervalMap imdiv[],int32_t div,int32_t i_div,int32_t ntop)
 
-    # int save_text_file(char filestem[],char basestem[],char err_msg[],FILE *ofile)
-    # int text_file_to_binaries(FILE *infile,char buildpath[],char err_msg[])
-    # int C_int_max
+    # int32_t save_text_file(char filestem[],char basestem[],char err_msg[],FILE *ofile)
+    # int32_t text_file_to_binaries(FILE *infile,char buildpath[],char err_msg[])
+    # int32_t C_int_max
 
 # cdef extern from "ncls/src/utarray.h":
 
@@ -109,14 +109,14 @@ cdef extern from "ncls/src/intervaldb.h":
 #     utarray_free(UT_array *a)
 #     UT_array utarray_new(UT_array *a, UT_icd *icd)
 #     utarray_len(UT_array *a)
-#     int* utarray_eltptr(UT_array *a, int j)
+#     int32_t* utarray_eltptr(UT_array *a, int32_t j)
 #     utarray_push_back(UT_array *a, void *p)
 
 
 # cdef class NCLS:
-#     cdef int n
-#     cdef int ntop
-#     cdef int nlists
+#     cdef int32_t n
+#     cdef int32_t ntop
+#     cdef int32_t nlists
 #     cdef IntervalMap *im
 #     cdef SublistHeader *subheader
 
@@ -132,7 +132,7 @@ cdef extern from "ncls/src/intervaldb.h":
 #     const UT_icd ut_int_icd
 
 #     void utarray_new(UT_array *a, UT_icd *icd)
-#     int utarray_len(UT_array *a)
-#     int* utarray_eltptr(UT_array *a, int j)
+#     int32_t utarray_len(UT_array *a)
+#     int32_t* utarray_eltptr(UT_array *a, int32_t j)
 #     void utarray_push_back(UT_array *a, void *p)
 #     void utarray_free(UT_array *a)

--- a/ncls/src/intervaldb.c
+++ b/ncls/src/intervaldb.c
@@ -1,5 +1,3 @@
-#include <sys/time.h>
-
 #include "intervaldb.h"
 
 int C_int_max=INT_MAX; /* KLUDGE TO LET PYREX CODE ACCESS VALUE OF INT_MAX MACRO */

--- a/ncls/src/intervaldb32.c
+++ b/ncls/src/intervaldb32.c
@@ -1,5 +1,3 @@
-#include <sys/time.h>
-
 #include "intervaldb32.h"
 
 

--- a/ncls/src/ncls.pyx
+++ b/ncls/src/ncls.pyx
@@ -4,7 +4,7 @@ import sys
 
 cimport cython
 
-# from cython.stdint import int32
+from libc.stdint cimport int32_t, int64_t
 
 cimport ncls.src.cncls as cn
 
@@ -22,14 +22,14 @@ cdef class NCLS64:
 
     cdef cn.SublistHeader *subheader
     cdef cn.IntervalMap *im
-    cdef int n, ntop
-    cdef int nlists
+    cdef int32_t n, ntop
+    cdef int32_t nlists
 
     # build NCLS from array of starts, ends, values
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.initializedcheck(False)
-    def __cinit__(self, const long [::1] starts=None, const long [::1] ends=None, const long [::1] ids=None):
+    def __cinit__(self, const int64_t [::1] starts=None, const int64_t [::1] ends=None, const int64_t [::1] ids=None):
 
         if None in (starts, ends, ids):
             return
@@ -37,7 +37,7 @@ cdef class NCLS64:
         if len(starts) == 0 or len(ends) == 0 or len(ids) == 0:
             return
 
-        cdef int i
+        cdef int32_t i
         cdef length = len(starts)
         self.close() # DUMP OUR EXISTING MEMORY
         self.n = len(starts)
@@ -48,7 +48,7 @@ cdef class NCLS64:
         for i in range(length):
             self.im[i].start = starts[i]
             self.im[i].end = ends[i]
-            self.im[i].target_id = <long> ids[i]
+            self.im[i].target_id = <int64_t> ids[i]
             self.im[i].sublist = -1
 
         self.subheader = cn.build_nested_list(self.im, self.n, &(self.ntop), &(self.nlists))
@@ -56,8 +56,8 @@ cdef class NCLS64:
     def intervals(self, take=None):
         intervals = []
 
-        cdef int i = 0
-        cdef int _take = int(take) if not take is None else len(self)
+        cdef int32_t i = 0
+        cdef int32_t _take = np.int32(take) if not take is None else len(self)
         if not self.im: # if empty
             return []
 
@@ -70,18 +70,18 @@ cdef class NCLS64:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.initializedcheck(False)
-    cpdef all_overlaps_both(self, const long [::1] starts, const long [::1] ends, const long [::1] indexes):
+    cpdef all_overlaps_both(self, const int64_t [::1] starts, const int64_t [::1] ends, const int64_t [::1] indexes):
 
-        cdef int i = 0
-        cdef int nhit = 0
-        cdef int length = len(starts)
-        cdef int loop_counter = 0
-        cdef int nfound = 0
+        cdef int32_t i = 0
+        cdef int32_t nhit = 0
+        cdef int32_t length = len(starts)
+        cdef int32_t loop_counter = 0
+        cdef int32_t nfound = 0
 
-        output_arr = np.zeros(length, dtype=long)
-        output_arr_other = np.zeros(length, dtype=long)
-        cdef long [::1] output
-        cdef long [::1] output_other
+        output_arr = np.zeros(length, dtype=np.int64)
+        output_arr_other = np.zeros(length, dtype=np.int64)
+        cdef int64_t [::1] output
+        cdef int64_t [::1] output_other
 
         output = output_arr
         output_other = output_arr_other
@@ -138,16 +138,16 @@ cdef class NCLS64:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.initializedcheck(False)
-    cpdef all_overlaps_self(self, const long [::1] starts, const long [::1] ends, const long [::1] indexes):
+    cpdef all_overlaps_self(self, const int64_t [::1] starts, const int64_t [::1] ends, const int64_t [::1] indexes):
 
-        cdef int i
-        cdef int nhit = 0
-        cdef int length = len(starts)
-        cdef int loop_counter = 0
-        cdef int nfound = 0
+        cdef int32_t i
+        cdef int32_t nhit = 0
+        cdef int32_t length = len(starts)
+        cdef int32_t loop_counter = 0
+        cdef int32_t nfound = 0
 
-        output_arr = np.zeros(length, dtype=long)
-        cdef long [::1] output
+        output_arr = np.zeros(length, dtype=np.int64)
+        cdef int64_t [::1] output
 
         output = output_arr
 
@@ -214,15 +214,15 @@ cdef class NCLS64:
 
         return None
 
-    def find_overlap(self, int start, int end):
+    def find_overlap(self, int32_t start, int32_t end):
         if not self.im: # RAISE EXCEPTION IF NO DATA
             return []
 
         return NCLSIterator(start, end, self)
 
 
-    cpdef has_overlap(self, int start, int end):
-        cdef int nhit = 0
+    cpdef has_overlap(self, int32_t start, int32_t end):
+        cdef int32_t nhit = 0
 
         cdef cn.IntervalIterator *it
         cdef cn.IntervalMap im_buf[1024]
@@ -249,25 +249,25 @@ cdef class NCLS64:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.initializedcheck(False)
-    cpdef set_difference_helper(self, const long [::1] starts, const long [::1] ends, const long [::1] indexes):
+    cpdef set_difference_helper(self, const int64_t [::1] starts, const int64_t [::1] ends, const int64_t [::1] indexes):
 
-        cdef int i
-        cdef int nhit = 0
-        cdef int nfound = 0
-        cdef int nstart = 0
-        cdef int nend = 0
-        cdef int length = len(starts)
-        cdef int loop_counter = 0
-        cdef int overlap_type_nb = 0
-        cdef int na = -1
+        cdef int32_t i
+        cdef int32_t nhit = 0
+        cdef int32_t nfound = 0
+        cdef int32_t nstart = 0
+        cdef int32_t nend = 0
+        cdef int32_t length = len(starts)
+        cdef int32_t loop_counter = 0
+        cdef int32_t overlap_type_nb = 0
+        cdef int32_t na = -1
 
 
         output_arr = np.zeros(length, dtype=np.int64)
         output_arr_start = np.zeros(length, dtype=np.int64)
         output_arr_end = np.zeros(length, dtype=np.int64)
-        cdef long [::1] output
-        cdef long [::1] output_start
-        cdef long [::1] output_end
+        cdef int64_t [::1] output
+        cdef int64_t [::1] output_start
+        cdef int64_t [::1] output_end
 
         output = output_arr
         output_start = output_arr_start
@@ -350,7 +350,7 @@ cdef class NCLS64:
 
                             output_start[nfound] = -1
                             output_end[nfound] = -1
-                            output[nfound] = <long> indexes[loop_counter]
+                            output[nfound] = <int64_t> indexes[loop_counter]
                             nfound += 1
                         else:
                             if im_buf[i].start > nstart:
@@ -385,17 +385,17 @@ cdef class NCLS64:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.initializedcheck(False)
-    cpdef first_overlap_both(self, const long [::1] starts, const long [::1] ends, const long [::1] indexes):
+    cpdef first_overlap_both(self, const int64_t [::1] starts, const int64_t [::1] ends, const int64_t [::1] indexes):
 
-        cdef int ix = 0
-        cdef int length = len(starts)
-        cdef int loop_counter = 0
-        cdef int nfound = 0
+        cdef int32_t ix = 0
+        cdef int32_t length = len(starts)
+        cdef int32_t loop_counter = 0
+        cdef int32_t nfound = 0
 
-        output_arr = np.zeros(length, dtype=np.long)
-        output_arr_other = np.zeros(length, dtype=np.long)
-        cdef long [::1] output
-        cdef long [::1] output_other
+        output_arr = np.zeros(length, dtype=np.int64)
+        output_arr_other = np.zeros(length, dtype=np.int64)
+        cdef int64_t [::1] output
+        cdef int64_t [::1] output_other
 
         output = output_arr
         output_other = output_arr_other
@@ -425,19 +425,19 @@ cdef class NCLS64:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.initializedcheck(False)
-    cpdef all_containments_both(self, const long [::1] starts, const long [::1] ends, const long [::1] indexes):
+    cpdef all_containments_both(self, const int64_t [::1] starts, const int64_t [::1] ends, const int64_t [::1] indexes):
 
-        cdef int i
-        cdef int nhit = 0
-        cdef int length = len(starts)
-        cdef int loop_counter = 0
-        cdef int nfound = 0
-        cdef int start, end
+        cdef int32_t i
+        cdef int32_t nhit = 0
+        cdef int32_t length = len(starts)
+        cdef int32_t loop_counter = 0
+        cdef int32_t nfound = 0
+        cdef int32_t start, end
 
-        output_arr = np.zeros(length, dtype=np.long)
-        output_arr_other = np.zeros(length, dtype=np.long)
-        cdef long [::1] output
-        cdef long [::1] output_other
+        output_arr = np.zeros(length, dtype=np.int64)
+        output_arr_other = np.zeros(length, dtype=np.int64)
+        cdef int64_t [::1] output
+        cdef int64_t [::1] output_other
 
         output = output_arr
         output_other = output_arr_other
@@ -495,18 +495,18 @@ cdef class NCLS64:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.initializedcheck(False)
-    cpdef has_overlaps(self, const long [::1] starts, const long [::1] ends, const long [::1] indexes):
+    cpdef has_overlaps(self, const int64_t [::1] starts, const int64_t [::1] ends, const int64_t [::1] indexes):
 
-        cdef int i = 0
-        cdef int ix = 0
-        cdef int length = len(starts)
-        cdef int nfound = 0
+        cdef int32_t i = 0
+        cdef int32_t ix = 0
+        cdef int32_t length = len(starts)
+        cdef int32_t nfound = 0
 
         if not self.im: # if empty
             return []
 
-        output_arr = np.zeros(length, dtype=long)
-        cdef long [::1] output
+        output_arr = np.zeros(length, dtype=np.int64)
+        cdef int64_t [::1] output
         output = output_arr
 
         for i in range(length):
@@ -528,10 +528,10 @@ cdef class NCLSIterator:
     cdef cn.IntervalIterator *it
     cdef cn.IntervalIterator *it_alloc
     cdef cn.IntervalMap im_buf[1024]
-    cdef int nhit, start, end, ihit
+    cdef int32_t nhit, start, end, ihit
     cdef NCLS64 db
 
-    def __cinit__(self, long start, long end, NCLS64 db not None):
+    def __cinit__(self, int64_t start, int64_t end, NCLS64 db not None):
         self.it = cn.interval_iterator_alloc()
         self.it_alloc = self.it
         self.start = start
@@ -545,8 +545,8 @@ cdef class NCLSIterator:
         return self
 
 
-    cdef int cnext(self): # c VERSION OF ITERATOR next METHOD RETURNS INDEX
-        cdef int i
+    cdef int32_t cnext(self): # c VERSION OF ITERATOR next METHOD RETURNS INDEX
+        cdef int32_t i
         if self.ihit >= self.nhit: # TRY TO GET ONE MORE BUFFER CHUNK OF HITS
             if self.it == NULL: # ITERATOR IS EXHAUSTED
                 return -1
@@ -565,7 +565,7 @@ cdef class NCLSIterator:
 
     # PYTHON VERSION OF next RETURNS HIT AS A TUPLE
     def __next__(self): # PYREX USES THIS NON-STANDARD NAME INSTEAD OF next()!!!
-        cdef int i
+        cdef int32_t i
         i = self.cnext()
         if i >= 0:
             return (self.im_buf[i].start, self.im_buf[i].end, self.im_buf[i].target_id)
@@ -577,7 +577,7 @@ cdef class NCLSIterator:
         cn.free_interval_iterator(self.it_alloc)
 
 
-    def find_overlap(self, int start, int end):
+    def find_overlap(self, int32_t start, int32_t end):
         if not self.im:
             return []
 


### PR DESCRIPTION
Just switched out the datatypes as mentioned in #6. Tried looking in the `tests` folder for unit tests to verify correctness, but wasn't too sure what was the expected output of the `test_ncls.py` file.

As mentioned in the issue thread, I also had to delete `#include <sys/time.h>` for it to work on Windows, but am unsure if it affects CI, @endrebak replace it with something cross-platform compatible as you see fit :).